### PR TITLE
Fix prerequisites when not building WIN versions

### DIFF
--- a/avr-gcc-build.sh
+++ b/avr-gcc-build.sh
@@ -147,7 +147,10 @@ log()
 
 installPackages()
 {
-	local requiredPackages=("wget" "make" "mingw-w64" "gcc" "g++" "bzip2" "xz-utils" "autoconf" "texinfo" "libgmp-dev" "libmpfr-dev" "libexpat1-dev")
+	local requiredPackages=("wget" "make" "gcc" "g++" "bzip2" "xz-utils" "autoconf" "texinfo" "libgmp-dev" "libmpfr-dev" "libexpat1-dev")
+	if [[ $FOR_WINX64 -ne 0 || $FOR_WINX86 -ne 0 ]]; then
+		requiredPackages+=("mingw-w64")
+	fi
 
 	if [[ $EUID -ne 0 ]]; then
 		log "Not running as root user. Checking whether all required packages are installed..."


### PR DESCRIPTION
Only include mingw-w64 as a prerequisite if at least 1 of FOR_WINX64 or FOR_WINX86 is non-zero.

Also, **_very_** nice build script!  Thanks!