### PR TITLE
Extra paranoia when using "rm -rf"

### DIFF
--- a/avr-gcc-build.sh
+++ b/avr-gcc-build.sh
@@ -175,7 +175,7 @@ installPackages()
 
 makeDir()
 {
-	rm -rf "$1/"
+	rm -rf "$1"
 	mkdir -p "$1"
 }
 
@@ -257,7 +257,7 @@ confMake()
 	../configure --prefix=$1 $2 $3 --build=`${4:-../config.guess}`
 	make -j $JOBCOUNT
 	make install-strip
-	rm -rf *
+	rm -rf -- *
 }
 
 buildBinutils()


### PR DESCRIPTION
Two small tweaks to makes sure worst-case scenarios can't cause harm when "rm -rf" is used.

First tweak:  `rm -rf "$1/"` if there is an empty first argument becomes `rm -rf /`.  This shouldn't be possible but accidental edits can happen (e.g., if someone is tweaking default versions), and someone might also run the script under sudo if they want to install directly into a root-owned location.  Solve by instead  `rm -rf "$1"`

Second tweak:  `rm -rf *` if any file names in the glob start with a dash (should never happen, but could) it can be interpreted as an option.  Solve by  `rm -rf -- *` to ensure all glob results are treated as files.